### PR TITLE
Refactor the 'watch' command into a flag. Write to the file once by default.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -54,7 +54,7 @@ function extract_boolean_flags (args)
     return flags;
 }
 
-let options = {
+let defaults = {
     prefix: 'u-',
     breakpoints: {},
     directory: [],
@@ -78,7 +78,10 @@ try {
     filesystem.accessSync(path, fs.F_OK);
 
     options = JSON.parse(filesystem.readFileSync(path, 'utf8'));
-} catch (error) {}
+    options = Object.assign(defaults, options);
+} catch (error) {
+    options = defaults;
+}
 
 // Load the flags.
 options.flags = flags;

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -9,6 +9,16 @@ let Config = require('./src/Config');
  */
 function extract_flags(args)
 {
+    let defaults = {'--watch': false};
+
+    let boolean_flags = extract_boolean_flags(args);
+    let argument_flags = extract_flags_with_arguments(args);
+
+    return Object.assign(defaults, boolean_flags, argument_flags);
+}
+
+function extract_flags_with_arguments (args)
+{
     let allowed_flags = ['--ignore', '-i', '--output', '-o'];
     let flags = {};
 
@@ -26,8 +36,35 @@ function extract_flags(args)
     return flags;
 }
 
+function extract_boolean_flags (args) 
+{
+    let allowed_flags = ['--watch', '-w'];
+    let flags = {};
+
+    for (flag of allowed_flags) {
+        if(! args.includes(flag)) {
+            continue;
+        }
+
+        let key = args.splice(args.indexOf(flag), 1);
+
+        flags[key] = true;
+    }
+
+    return flags;
+}
+
+let options = {
+    prefix: 'u-',
+    breakpoints: {},
+    directory: [],
+    output: null,
+    emmet: {
+        syntax: 'css',
+        "snippets": {}
+    },
+};
 let path = `${process.cwd()}/wyldstyle.json`;
-let source = 'cli';
 let args = process.argv;
 let flags = extract_flags(args);
 
@@ -41,7 +78,6 @@ try {
     filesystem.accessSync(path, fs.F_OK);
 
     options = JSON.parse(filesystem.readFileSync(path, 'utf8'));
-    source  = path;
 } catch (error) {}
 
 // Load the flags.
@@ -52,12 +88,17 @@ if ('--output' in flags || '-o' in flags) {
     options.output = flags['--output'] || flags['-o'];
 }
 
+// @todo add a flag when an output is not given.
+if (! options.output) {
+    throw 'No --output file specified';
+}
+
 emmet.loadPreferences(options.emmet.preferences);
 emmet.loadSnippets({
     "css": { "snippets": options.emmet.snippets }
 });
 
 module.exports = {
-    config: new Config(options, source),
+    config: new Config(options),
     emmet:  emmet,
 };

--- a/index.js
+++ b/index.js
@@ -10,8 +10,4 @@ if (app.config.get('directory').length == 0) {
 
 let flags = app.config.get('flags');
 
-if (flags['--watch']) {
-    (new Watcher(app)).start();
-} else {
-
-}
+(new Watcher(app)).start();

--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ if (app.config.get('directory').length == 0) {
     process.exit();
 }
 
-console.log(`Wyldstyle config: ${app.config.get('source')}`);
+let flags = app.config.get('flags');
 
-let watcher = new Watcher(app);
+if (flags['--watch']) {
+    (new Watcher(app)).start();
+} else {
 
-watcher.start();
+}

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # Wyldstyle
 
+~~~bash
+$ ws directory1 file1.html directory2 --watch --output _utilities.scss
+~~~
+
 # Todo
 - [ ] Logo?
 - [ ] Documentation?

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,28 @@
 $ ws directory1 file1.html directory2 --watch --output _utilities.scss
 ~~~
 
+~~~
+{
+    "breakpoints": {
+        "m":  "breakpoint(mobile)",
+        "l":  "breakpoint(tablet)",
+        "xl":  "breakpoint(retina)"
+    },
+    "directory": ["file1.html"],
+    "output": "_utilities.scss",
+    "emmet": {
+        "syntax": "scss",
+        "preferences": {
+            "caniuse.enabled": false,
+            "css.autoInsertVendorPrefixes": false
+        },
+        "snippets": {
+            "m:0a": "margin: 0 auto"
+        }
+    }
+}
+~~~
+
 # Todo
 - [ ] Logo?
 - [ ] Documentation?

--- a/src/Config.js
+++ b/src/Config.js
@@ -4,25 +4,10 @@ class Config {
     /**
      * Create a new config store.
      * @param  {Object} config = {}
-     * @param  {String} source = null
      * @return {Config}
      */
-    constructor(config = {}, source = null) {
-        let defaults = {
-            prefix: 'u-',
-            breakpoints: {},
-            directory: null,
-            output: null,
-            emmet: {
-                syntax: 'css',
-                "snippets": {}
-            },
-        };
-
-        Object.assign(defaults, config);
-
-        this.config = defaults;
-        this.config.source = source;
+    constructor(config = {}) {
+        this.config = config;
     }
 
     /**

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -76,6 +76,10 @@ class Watcher
                     if (error) { return console.log(error); }
 
                     console.log(`File saved on ${this.app.config.get('output')}`);
+
+                    if (! this.app.config.get('flags')['--watch']) {
+                        process.exit();
+                    }
                 });
 
             });

--- a/src/Writer.js
+++ b/src/Writer.js
@@ -1,0 +1,8 @@
+class Writer 
+{
+    constructor (app) {
+        this.app = app;
+    }
+}
+
+module.exports = Writer;

--- a/src/Writer.js
+++ b/src/Writer.js
@@ -1,8 +1,0 @@
-class Writer 
-{
-    constructor (app) {
-        this.app = app;
-    }
-}
-
-module.exports = Writer;

--- a/test/Config.js
+++ b/test/Config.js
@@ -30,12 +30,6 @@ describe("Config", () => {
                 },
                 directory: "tests/mocks",
                 output:    "tests/mocks/wyldstyle.styl",
-                prefix:    "u-",
-                "emmet": {
-                    "syntax": "css",
-                    "snippets": {}
-                },
-                "source": null
             };
 
             assert.deepEqual(expected, config.all());


### PR DESCRIPTION
The initial behavior for wyldstyle watches the selected directories by default.

This pull request refactors out that behaviour out to a flag. `ws directory/ --watch --output utilities.css`

Also, I refactored out the default arguments into the `bootstrap.js`. Initially, it's located in the `Config.js` constructor but it does't really hit that part on actual usage since we already build the application config in the boostrap file.
