### PR TITLE
Fix the readme config example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wyldstyle",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Emmet based CSS utility generator",
   "main": "index.js",
   "engine": "node 6.2.2",

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ Now, our config file should look something like this:
     "l":  "1024px",
     "xl": "1200px"
   },
-  "directory": ["assets/js", "templates"],
+  "directories": ["assets/js", "templates"],
   "output": "assets/scss/_utilities.scss",
   "emmet": {
     "syntax": "scss",


### PR DESCRIPTION
Start using `directories` instead of `directory` for proper semantics.
